### PR TITLE
Remove license headers from Android example files to fix build

### DIFF
--- a/example/android/app/src/main/res/drawable/launch_background.xml
+++ b/example/android/app/src/main/res/drawable/launch_background.xml
@@ -1,19 +1,3 @@
-<!--
- Copyright 2023 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- -->
-
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">

--- a/example/android/app/src/main/res/values-night/styles.xml
+++ b/example/android/app/src/main/res/values-night/styles.xml
@@ -1,19 +1,3 @@
-<!--
- Copyright 2023 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- -->
-
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->

--- a/example/android/app/src/main/res/values/styles.xml
+++ b/example/android/app/src/main/res/values/styles.xml
@@ -1,19 +1,3 @@
-<!--
- Copyright 2023 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-      https://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- -->
-
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -42,6 +42,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
The license headers are causing a build issue when attempting to run the example:

```
⑆ flutter run
Using hardware rendering with device Android SDK built for arm64. If you notice graphics artifacts, consider enabling software rendering with "--enable-software-rendering".
Launching lib/main.dart on Android SDK built for arm64 in debug mode...
ERROR:/Users/bryanoltman/Documents/flutter-stager/example/android/app/src/main/res/values-night/styles.xml:17:6: Resource and asset merger: The processing instruction target matching "[xX][mM][lL]" is not allowed.
    org.xml.sax.SAXParseException; lineNumber: 17; columnNumber: 6; The processing instruction target matching "[xX][mM][lL]" is not allowed.
    	at org.apache.xerces.util.ErrorHandlerWrapper.createSAXParseException(Unknown Source)
    	at org.apache.xerces.util.ErrorHandlerWrapper.fatalError(Unknown Source)
    	at org.apache.xerces.impl.XMLErrorReporter.reportError(Unknown Source)
    	at org.apache.xerces.impl.XMLErrorReporter.reportError(Unknown Source)
    	at org.apache.xerces.impl.XMLErrorReporter.reportError(Unknown Source)
    	at org.apache.xerces.impl.XMLScanner.reportFatalError(Unknown Source)
    	at org.apache.xerces.impl.XMLScanner.scanPIData(Unknown Source)
    	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanPIData(Unknown Source)
    	at org.apache.xerces.impl.XMLScanner.scanPI(Unknown Source)
    	at org.apache.xerces.impl.XMLDocumentScannerImpl$PrologDispatcher.dispatch(Unknown Source)
    	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
    	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
    	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
    	at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
    	at org.apache.xerces.parsers.AbstractSAXParser.parse(Unknown Source)
    	at org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser.parse(Unknown Source)
    	at org.apache.xerces.jaxp.SAXParserImpl.parse(Unknown Source)
    	at com.android.utils.PositionXmlParser.parseInternal(PositionXmlParser.java:268)
    	at com.android.utils.PositionXmlParser.parseInternal(PositionXmlParser.java:217)
```